### PR TITLE
fix: translating products lists

### DIFF
--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -1,4 +1,6 @@
 {
+    "Windows authentication": "Windows authentication",
+    "Network shared folders": "Network shared folders",
     "edit": "Edit",
     "save": "Save",
     "errors": {

--- a/src/views/UserAccount.vue
+++ b/src/views/UserAccount.vue
@@ -132,7 +132,7 @@ async function changePassword() {
         <p class="description-text">{{ $t('account_settings.change_password_description') }}</p>
         <ul class="description-text list-disc pl-6">
           <li v-for="(product, key) in config.services" :key="key">
-            {{ product }}
+            {{ t(product) }}
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Allowing translation of strings from the server, strings that are not found in the translation will be left untouched.
