### PR TITLE
chore: remove vue-tailwind-lib dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.8.2",
       "dependencies": {
         "@headlessui/vue": "^1.7.16",
-        "@nethesis/vue-components": "^0.4.0",
-        "@nethserver/vue-tailwind-lib": "^0.1.1",
+        "@nethesis/vue-components": "^0.16.0",
         "axios": "^1.6.2",
         "pinia": "^2.1.7",
         "vue": "^3.3.7"
@@ -1458,6 +1457,7 @@
     "node_modules/@fortawesome/free-solid-svg-icons": {
       "version": "6.4.0",
       "resolved": "git+ssh://git@github.com/nethesis/Font-Awesome.git#b4030d0e6db57a6eb408f6da6b9ddbdc22793c93",
+      "dev": true,
       "hasInstallScript": true,
       "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
@@ -1471,6 +1471,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
       "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+      "dev": true,
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -1741,14 +1742,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@nethesis/nethesis-light-svg-icons": {
       "version": "6.2.1",
       "resolved": "git+ssh://git@github.com/nethesis/Font-Awesome.git#3e110fb0ae63495fb8b7ca9811e5f07eed1ac962",
@@ -1796,14 +1789,18 @@
       }
     },
     "node_modules/@nethesis/vue-components": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-0.4.0.tgz",
-      "integrity": "sha512-LqG6V0KLX75UpM//9oy9XRqtYiVP2XW4/oQPWfsNf1Bb+i47KMk5pctueXM5Jmt4y6EqEpTls/DQ9xXwvbABRQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@nethesis/vue-components/-/vue-components-0.16.0.tgz",
+      "integrity": "sha512-sl1fu3lHl8F6gA+WabGF05BSZOjPsU6bjyY+VJ+p8gM7r3qECvorRgxhSNDGudkeu8gZ0XRoaez3C7vhPPIlrA==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.1",
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/vue-fontawesome": "^3.0.5",
         "@headlessui/vue": "^1.7.16",
+        "@vueuse/core": "^10.7.0",
+        "date-fns": "^2.30.0",
+        "date-fns-tz": "^2.0.0",
+        "lodash-es": "^4.17.21",
         "uuid": "^9.0.1",
         "vue": "^3.3.4",
         "vue-tippy": "^6.3.1"
@@ -1819,26 +1816,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@nethserver/vue-tailwind-lib": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@nethserver/vue-tailwind-lib/-/vue-tailwind-lib-0.1.1.tgz",
-      "integrity": "sha512-hgvOnJWZT1fzjapE58thgmLbrblurXzL3WSS1TsZZ48ThkWDmrP0TDDBvZjfzwFNuxBJJyCyIsBm4A0CGDyB/g==",
-      "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.4.0",
-        "@fortawesome/free-solid-svg-icons": "github:nethesis/Font-Awesome#solid",
-        "@fortawesome/vue-fontawesome": "^3.0.3",
-        "@headlessui/vue": "^1.7.14",
-        "@types/lodash-es": "^4.17.12",
-        "@vueuse/core": "^10.3.0",
-        "classnames": "^2.3.2",
-        "date-fns": "^2.30.0",
-        "date-fns-tz": "^2.0.0",
-        "lodash-es": "^4.17.21",
-        "uid": "^2.0.2",
-        "vue": "^3.2.47",
-        "vue-tippy": "^6.3.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1960,19 +1937,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
@@ -2926,11 +2890,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -6418,17 +6377,6 @@
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/uid": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
-      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
-      "dependencies": {
-        "@lukeed/csprng": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "dependencies": {
     "@headlessui/vue": "^1.7.16",
-    "@nethesis/vue-components": "^0.4.0",
-    "@nethserver/vue-tailwind-lib": "^0.1.1",
+    "@nethesis/vue-components": "^0.16.0",
     "axios": "^1.6.2",
     "pinia": "^2.1.7",
     "vue": "^3.3.7"

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -6,8 +6,12 @@
 
 @layer base {
   html {
-    @apply overflow-x-hidden text-gray-900 dark:text-gray-50;
+    @apply overflow-x-hidden;
   }
+}
+
+body {
+  @apply bg-gray-50 text-sm text-gray-700 dark:bg-gray-900 dark:text-gray-100;
 }
 
 .h1 {

--- a/src/components/CreateGroupDrawer.vue
+++ b/src/components/CreateGroupDrawer.vue
@@ -7,7 +7,7 @@ import {
   type NeComboboxOption,
   NeSkeleton,
   NeTextInput
-} from '@nethserver/vue-tailwind-lib'
+} from '@nethesis/vue-components'
 import { useUsers } from '@/composables/useUsers'
 import axios from 'axios'
 

--- a/src/components/CreateUserDrawer.vue
+++ b/src/components/CreateUserDrawer.vue
@@ -1,14 +1,15 @@
 <script lang="ts" setup>
 import SideDrawer from '@/components/SideDrawer.vue'
 import {
+  NeInlineNotification,
+  NeSkeleton,
   NeButton,
   NeCombobox,
   type NeComboboxOption,
   NeFormItemLabel,
   NeTextInput,
   NeToggle
-} from '@nethserver/vue-tailwind-lib'
-import { NeInlineNotification, NeSkeleton } from '@nethesis/vue-components'
+} from '@nethesis/vue-components'
 import { computed, ref, watch } from 'vue'
 import axios from 'axios'
 import type { BaseResponse } from '@/lib/axiosHelpers'

--- a/src/components/DeleteGroupModal.vue
+++ b/src/components/DeleteGroupModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { NeInlineNotification, NeModal } from '@nethserver/vue-tailwind-lib'
+import { NeInlineNotification, NeModal } from '@nethesis/vue-components'
 import type { Group } from '@/composables/useGroups'
 import axios from 'axios'
 import { ref } from 'vue'

--- a/src/components/DeleteGroupModal.vue
+++ b/src/components/DeleteGroupModal.vue
@@ -47,6 +47,7 @@ function deleteGroup() {
     primary-button-kind="danger"
     :primary-button-loading="loading"
     :primary-button-disabled="loading"
+    :close-aria-label="$t('close')"
     @primary-click="deleteGroup"
     @close="handleClose"
   >

--- a/src/components/DeleteUserModal.vue
+++ b/src/components/DeleteUserModal.vue
@@ -57,6 +57,7 @@ function deleteUser() {
     primary-button-kind="danger"
     :primary-button-loading="loading"
     :primary-button-disabled="loading"
+    :close-aria-label="$t('close')"
     @primary-click="deleteUser"
     @close="handleClose"
   >

--- a/src/components/DeleteUserModal.vue
+++ b/src/components/DeleteUserModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { NeInlineNotification, NeModal } from '@nethserver/vue-tailwind-lib'
+import { NeInlineNotification, NeModal } from '@nethesis/vue-components'
 import type { User } from '@/composables/useUsers'
 import { ref, watch } from 'vue'
 import axios from 'axios'

--- a/src/components/EditGroupDrawer.vue
+++ b/src/components/EditGroupDrawer.vue
@@ -3,13 +3,13 @@ import SideDrawer from '@/components/SideDrawer.vue'
 import type { Group } from '@/composables/useGroups'
 import { ref, watch } from 'vue'
 import {
+  NeSkeleton,
   NeButton,
   NeCombobox,
   type NeComboboxOption,
   NeInlineNotification,
   NeTextInput
-} from '@nethserver/vue-tailwind-lib'
-import { NeSkeleton } from '@nethesis/vue-components'
+} from '@nethesis/vue-components'
 import { useUsers } from '@/composables/useUsers'
 import axios from 'axios'
 

--- a/src/components/EditUserDrawer.vue
+++ b/src/components/EditUserDrawer.vue
@@ -1,16 +1,17 @@
 <script lang="ts" setup>
 import type { UserList } from '@/components/UserList.vue'
 import { computed, ref, watch } from 'vue'
+import { useGroups } from '@/composables/useGroups'
 import {
+  NeInlineNotification,
+  NeSkeleton,
   NeButton,
   NeCombobox,
   type NeComboboxOption,
   NeFormItemLabel,
   NeTextInput,
   NeToggle
-} from '@nethserver/vue-tailwind-lib'
-import { useGroups } from '@/composables/useGroups'
-import { NeInlineNotification, NeSkeleton } from '@nethesis/vue-components'
+} from '@nethesis/vue-components'
 import type { BaseResponse } from '@/lib/axiosHelpers'
 import axios from 'axios'
 import SideDrawer from '@/components/SideDrawer.vue'

--- a/src/components/EditUserPasswordDrawer.vue
+++ b/src/components/EditUserPasswordDrawer.vue
@@ -2,12 +2,11 @@
 import type { User } from '@/composables/useUsers'
 import { ref, watch } from 'vue'
 import SideDrawer from '@/components/SideDrawer.vue'
-import { NeButton, NeTextInput } from '@nethserver/vue-tailwind-lib'
 import { MessageBag } from '@/lib/validation'
 import { useI18n } from 'vue-i18n'
 import axios from 'axios'
 import type { BaseResponse } from '@/lib/axiosHelpers'
-import { NeInlineNotification, NeSkeleton } from '@nethesis/vue-components'
+import { NeInlineNotification, NeSkeleton, NeButton, NeTextInput } from '@nethesis/vue-components'
 import PasswordRequirementList from '@/components/PasswordRequirementList.vue'
 import { usePasswordPolicy } from '@/composables/usePasswordPolicy'
 

--- a/src/components/GroupsList.vue
+++ b/src/components/GroupsList.vue
@@ -1,7 +1,6 @@
 <script lang="ts" setup>
 import { faEdit, faPlusCircle } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
-import { NeButton, NeDropdown } from '@nethserver/vue-tailwind-lib'
 import {
   NeSkeleton,
   NeInlineNotification,
@@ -10,7 +9,9 @@ import {
   NeTableHeadCell,
   NeTableRow,
   NeTableBody,
-  NeTableCell
+  NeTableCell,
+  NeButton,
+  NeDropdown
 } from '@nethesis/vue-components'
 import { type Group, useGroups } from '@/composables/useGroups'
 import { ref } from 'vue'

--- a/src/components/SideDrawer.vue
+++ b/src/components/SideDrawer.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faX } from '@fortawesome/free-solid-svg-icons'
-import { NeButton } from '@nethserver/vue-tailwind-lib'
+import { NeButton } from '@nethesis/vue-components'
 import { Dialog, DialogPanel, TransitionChild, TransitionRoot } from '@headlessui/vue'
 
 defineProps<{

--- a/src/components/UserList.vue
+++ b/src/components/UserList.vue
@@ -5,13 +5,6 @@ import {
   faEdit,
   faPlusCircle
 } from '@fortawesome/free-solid-svg-icons'
-import {
-  NeButton,
-  type NeComboboxOption,
-  NeDropdown,
-  NeInlineNotification,
-  NeSkeleton
-} from '@nethserver/vue-tailwind-lib'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { type User, useUsers } from '@/composables/useUsers'
 import { useGroups } from '@/composables/useGroups'
@@ -22,7 +15,12 @@ import {
   NeTableCell,
   NeTableHead,
   NeTableHeadCell,
-  NeTableRow
+  NeTableRow,
+  NeButton,
+  type NeComboboxOption,
+  NeDropdown,
+  NeInlineNotification,
+  NeSkeleton
 } from '@nethesis/vue-components'
 import DeleteUserModal from '@/components/DeleteUserModal.vue'
 import { useI18n } from 'vue-i18n'

--- a/src/composables/useUsers.ts
+++ b/src/composables/useUsers.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from 'vue'
 import axios from 'axios'
-import type { NeComboboxOption } from '@nethserver/vue-tailwind-lib'
+import type { NeComboboxOption } from '@nethesis/vue-components'
 
 export interface User {
   display_name: string

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -3,6 +3,7 @@
     "Network shared folders": "Network shared folders",
     "edit": "Edit",
     "save": "Save",
+    "close": "Close",
     "errors": {
         "generic": "Error",
         "connection_aborted": "Couldn't connect to the server",

--- a/src/views/BaseTemplate.vue
+++ b/src/views/BaseTemplate.vue
@@ -8,7 +8,7 @@ import SidebarMenu from '@/components/SidebarMenu.vue'
 import { useRouter } from 'vue-router'
 import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons'
 import { ref } from 'vue'
-import { NeButton } from '@nethserver/vue-tailwind-lib'
+import { NeButton } from '@nethesis/vue-components'
 import NotificationHandler from '@/components/NotificationHandler.vue'
 import { useConfig } from '@/stores/config'
 

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
-import { NeButton, NeCheckbox, NeTextInput } from '@nethserver/vue-tailwind-lib'
-import { NeInlineNotification } from '@nethesis/vue-components'
+import { NeInlineNotification, NeButton, NeCheckbox, NeTextInput } from '@nethesis/vue-components'
 import { ref } from 'vue'
 import { useAuth } from '@/composables/useAuth'
 import axios from 'axios'

--- a/src/views/UserAccount.vue
+++ b/src/views/UserAccount.vue
@@ -1,6 +1,5 @@
 <script lang="ts" setup>
-import { NeButton, NeTextInput } from '@nethserver/vue-tailwind-lib'
-import { NeInlineNotification, NeSkeleton } from '@nethesis/vue-components'
+import { NeInlineNotification, NeSkeleton, NeButton, NeTextInput } from '@nethesis/vue-components'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faSave } from '@fortawesome/free-solid-svg-icons'
 import { ref } from 'vue'

--- a/src/views/UserManager.vue
+++ b/src/views/UserManager.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { NeTabs } from '@nethserver/vue-tailwind-lib'
+import { NeTabs } from '@nethesis/vue-components'
 import { ref } from 'vue'
 import ContentPage from '@/components/ContentPage.vue'
 import GroupsList from '@/components/GroupsList.vue'

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,6 @@ export default {
   content: [
     './index.html',
     './src/**/*.{vue,js,ts,jsx,tsx}',
-    './node_modules/@nethserver/vue-tailwind-lib/dist/vue-tailwind-lib.es.js',
     './node_modules/@nethesis/vue-components/dist/**/*.js'
   ],
   theme: {


### PR DESCRIPTION
Remove `vue-tailwind-lib dependency`: all components have been migrated to `vue-components`.

Other changes:
- Set missing required prop `closeAriaLabel` for `NeModal`s
- Fix CSS style