### PR TITLE
fix(CreateUserDrawer): remove unnecessary config check for expirationEnforced

### DIFF
--- a/src/components/CreateUserDrawer.vue
+++ b/src/components/CreateUserDrawer.vue
@@ -248,7 +248,7 @@ function submit() {
               "
             />
           </div>
-          <div v-if="config.schema == 'ad' && expirationEnforced">
+          <div v-if="expirationEnforced">
             <NeFormItemLabel>{{ t('user_manager.no_password_expiration_policy') }}</NeFormItemLabel>
             <NeToggle
               v-model="noPasswordExpirationPolicy"


### PR DESCRIPTION
Eliminate the redundant configuration check for `expirationEnforced` in the CreateUserDrawer component. This simplifies the conditional rendering logic.

https://github.com/NethServer/dev/issues/7981