### PR TITLE
fix(router): land on role-appropriate page after login

### DIFF
--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -44,6 +44,13 @@ export function useAuth() {
   })
 
   /**
+   * Route name to land on based on role: admins go to the user list, restricted users go to their account page
+   */
+  const landingRouteName = computed((): string =>
+    scopes.value.length === 0 ? 'user_manager' : 'user_account'
+  )
+
+  /**
    * Login to the API, saving the token and expire date to localStorage
    * @param username
    * @param password
@@ -70,5 +77,5 @@ export function useAuth() {
     localStorage.removeItem(SCOPES_KEY)
   }
 
-  return { token, expire, uid, scopes, previouslyLogged, login, logout }
+  return { token, expire, uid, scopes, previouslyLogged, landingRouteName, login, logout }
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -12,7 +12,10 @@ const router = createRouter({
     {
       path: '/',
       name: 'home',
-      redirect: { name: 'user_account' },
+      redirect: () => {
+        const { landingRouteName } = useAuth()
+        return { name: landingRouteName.value }
+      },
       component: () => import('@/views/BaseTemplate.vue'),
       beforeEnter: () => {
         const { previouslyLogged } = useAuth()
@@ -44,9 +47,9 @@ const router = createRouter({
       name: 'login',
       component: () => import('@/views/LoginView.vue'),
       beforeEnter: () => {
-        const { previouslyLogged } = useAuth()
+        const { previouslyLogged, landingRouteName } = useAuth()
         if (previouslyLogged.value) {
-          return { name: 'user_account' }
+          return { name: landingRouteName.value }
         }
       }
     }

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -7,7 +7,7 @@ import { ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 
-const { login } = useAuth()
+const { login, landingRouteName } = useAuth()
 const router = useRouter()
 const config = useConfig()
 
@@ -27,7 +27,7 @@ async function handleLogin() {
     loading.value = true
     try {
       await login(username.value, password.value)
-      await router.replace({ name: 'user_account' })
+      await router.replace({ name: landingRouteName.value })
     } catch (exception: unknown) {
       if (axios.isAxiosError(exception) && exception.response != undefined) {
         if (exception.response.status == 401) {


### PR DESCRIPTION
## Summary
After login, admins now land on the user list; restricted users land on their account (change password) page. Previously everyone landed on the account page.

## Issue

References:
- https://github.com/nethserver/dev/issues/8036
- https://github.com/NethServer/dev/issues/8114

## How to test
Log in as an admin — should land on Users list. Log in as a restricted user — should land on account page.